### PR TITLE
added a link helper when the command isn't used properly

### DIFF
--- a/patrick.py
+++ b/patrick.py
@@ -226,6 +226,14 @@ class Patrick(commands.Bot):
                 message = reformat_relay_chat(self, message)
                 if message is None:
                     return
+                
+            elif message.content.startswith("/link"):
+                # If the message starts with /link, it's probably someone trying to link their account but not selecting the command from the popup.
+                await message.channel.send(
+                    f"{message.author.display_name}: Please use the `/link` command from the command popup as you type. Do not type it out manually."
+                )
+                await message.delete()
+                return
 
         await self.process_commands(message)
 


### PR DESCRIPTION
As requested by Fandit, some users will sometimes type `/link` and don't click the command. This potentially exposes their link token. The bot will now delete this and tell the user to click the command from the popup.