### PR TITLE
Remove the 180s default timeout from notifications so it doesn't stop working

### DIFF
--- a/cogs/notifications.py
+++ b/cogs/notifications.py
@@ -26,7 +26,7 @@ class RoleButton(discord.ui.Button):
 
 class NotificationsView(discord.ui.View):
     def __init__(self, bot, categories):
-        super().__init__()
+        super().__init__(timeout=None)
         self.bot = bot
 
         for category in categories:


### PR DESCRIPTION
Dpy adds a default 180 seconds timeout to any view. This means after 3 minutes it stops working.
This PR just makes a tiny change to remove this deafult timeout so the view stays active.