### PR TITLE
Make message content in the logs be spoiler tagged

### DIFF
--- a/util.py
+++ b/util.py
@@ -284,12 +284,12 @@ async def create_deletion_embed(
     if len(message.message_snapshots) > 0:
         embed.add_field(
             name="Forwarded Message Content",
-            value=message.message_snapshots[0].content or "No content",
+            value=f"||{message.message_snapshots[0].content}||" or "No content",
             inline=False,
         )
         attachments = [await attachment.to_file() for attachment in message.message_snapshots[0].attachments]
     else:
-        embed.add_field(name="Message Content", value=message.content or "No content", inline=False)
+        embed.add_field(name="Message Content", value=f"||{message.content}||" or "No content", inline=False)
         attachments = [await attachment.to_file() for attachment in message.attachments]
     embed.add_field(name="Channel", value=message.channel.jump_url, inline=True)
     embed.add_field(name="Context", value=message.jump_url, inline=True)


### PR DESCRIPTION
This fixes #44
No more obscene messages clearly visible in logs. You're welcome.
<img width="850" height="1037" alt="afbeelding" src="https://github.com/user-attachments/assets/f6e651e8-1327-4873-8475-23667c1f76a2" />
