### PR TITLE
Mesage removal fixes

### DIFF
--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -70,7 +70,7 @@ class Reminders(commands.Cog):
             user_id, channel_id, message = reminder
             channel = self.bot.get_channel(channel_id) or await self.bot.fetch_channel(channel_id)
             try:
-                await channel.send(f"<@{user_id}>{f': {message}' if message else ''}")
+                await channel.send(f"<@{user_id}>: {message}" if message else '')
             except discord.Forbidden:
                 # If the bot cannot send messages to the channel, skip it
                 continue

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -57,7 +57,7 @@ class Reminders(commands.Cog):
             for message, _, timestamp in reminders:
                     embed.add_field(
                         name=f"Reminder at {timestamp.strftime('%Y-%m-%d %H:%M:%S')}",
-                        value=f"Message: {message or "-"}",
+                        value=f"Message: {message or '-'}",
                         inline=False
                     )
             await ctx.reply(embed=embed)
@@ -70,7 +70,7 @@ class Reminders(commands.Cog):
             user_id, channel_id, message = reminder
             channel = self.bot.get_channel(channel_id) or await self.bot.fetch_channel(channel_id)
             try:
-                await channel.send(f"<@{user_id}>{f": {message}" if message else ""}")
+                await channel.send(f"<@{user_id}>{f': {message}' if message else ''}")
             except discord.Forbidden:
                 # If the bot cannot send messages to the channel, skip it
                 continue

--- a/util.py
+++ b/util.py
@@ -2,6 +2,7 @@ import re
 import typing
 from random import choice
 from copy import copy
+from io import StringIO
 
 import discord
 from discord import app_commands
@@ -284,13 +285,29 @@ async def create_deletion_embed(
     if len(message.message_snapshots) > 0:
         embed.add_field(
             name="Forwarded Message Content",
-            value=f"||{message.message_snapshots[0].content}||" or "No content",
+            value=f"||{return_or_truncate(message.message_snapshots[0].content, 500)}||" or "No content",
             inline=False,
         )
         attachments = [await attachment.to_file() for attachment in message.message_snapshots[0].attachments]
+        # On long message, provide a .txt file with full content
+        if len(message.message_snapshots[0].content) > 500:
+            full_content_file = discord.File(
+                fp=StringIO(message.message_snapshots[0].content),
+                filename=f"message_{message.id}_full_content.txt",
+                spoiler=True,
+            )
+            attachments.append(full_content_file)
     else:
-        embed.add_field(name="Message Content", value=f"||{message.content}||" or "No content", inline=False)
+        embed.add_field(name="Message Content", value=f"||{return_or_truncate(message.content, 500)}||" or "No content", inline=False)
         attachments = [await attachment.to_file() for attachment in message.attachments]
+        # On long message, provide a .txt file with full content
+        if len(message.content) > 500:
+            full_content_file = discord.File(
+                fp=StringIO(message.content),
+                filename=f"message_{message.id}_full_content.txt",
+                spoiler=True,
+            )
+            attachments.append(full_content_file)
     embed.add_field(name="Channel", value=message.channel.jump_url, inline=True)
     embed.add_field(name="Context", value=message.jump_url, inline=True)
     embed.set_footer(text=f"Message ID: {message.id}")

--- a/util.py
+++ b/util.py
@@ -285,10 +285,10 @@ async def create_deletion_embed(
     if len(message.message_snapshots) > 0:
         embed.add_field(
             name="Forwarded Message Content",
-            value=f"||{return_or_truncate(message.message_snapshots[0].content, 500)}||" or "No content",
+            value=f"||{return_or_truncate(message.message_snapshots[0].content, 500)}||" if len(message.message_snapshots[0].content) > 0 else "No content",
             inline=False,
         )
-        attachments = [await attachment.to_file() for attachment in message.message_snapshots[0].attachments]
+        attachments = [await attachment.to_file(spoiler=True) for attachment in message.message_snapshots[0].attachments]
         # On long message, provide a .txt file with full content
         if len(message.message_snapshots[0].content) > 500:
             full_content_file = discord.File(
@@ -298,8 +298,8 @@ async def create_deletion_embed(
             )
             attachments.append(full_content_file)
     else:
-        embed.add_field(name="Message Content", value=f"||{return_or_truncate(message.content, 500)}||" or "No content", inline=False)
-        attachments = [await attachment.to_file() for attachment in message.attachments]
+        embed.add_field(name="Message Content", value=f"||{return_or_truncate(message.content, 500)}||" if len(message.content) > 0 else "No content", inline=False)
+        attachments = [await attachment.to_file(spoiler=True) for attachment in message.attachments]
         # On long message, provide a .txt file with full content
         if len(message.content) > 500:
             full_content_file = discord.File(


### PR DESCRIPTION
This PR adds a list of small fixes to the remove message command:
- Long text no longer error out. Instead they will be truncated in the embed, and a spoilered .txt file is sent with the full content
- Attachments from the original message will now also send as spoilers
- When a message has no text content (like a message that's only images) it will properly display "no content"