### PR TITLE
Changed google command to use quote_plus from urllib.parse

### DIFF
--- a/cogs/randcommands.py
+++ b/cogs/randcommands.py
@@ -4,6 +4,7 @@ from asyncio import to_thread
 from io import BytesIO
 from random import choice, getrandbits, randint
 from time import perf_counter
+from urllib.parse import quote_plus
 import re
 
 import discord
@@ -225,7 +226,7 @@ class RandCommands(commands.Cog):
 
     @commands.command(help="Googles something.", aliases=["lmgtfy", "search"])
     async def google(self, ctx, *, query):
-        await reply(ctx, f"<https://www.google.com/search?q={query.replace(' ', '+')}>")
+        await reply(ctx, f"<https://www.google.com/search?q={quote_plus(query)}>")
 
     def prime_factors(self, n: int) -> list:
         i = 2


### PR DESCRIPTION
With the current version of the ,google command, using special characters (e.g. +) might result with the wrong google search. Instead, we can use the `quote_plus` function in the `urllib.parse` module to URL encode the query.